### PR TITLE
Patch: Update documentation for micro-frontend setup

### DIFF
--- a/documentations/00-index.md
+++ b/documentations/00-index.md
@@ -1,0 +1,17 @@
+# Documentation index
+
+This is the single entry point that links to detailed markdown files for this repository. Use this file to quickly find the guide you want to show on your channel or to reference when debugging.
+
+- [01-monorepo-lerna.md](01-monorepo-lerna.md) — Overview of monorepos and how Lerna & workspaces are configured and used in this repo.
+- [02-microfrontends-architecture.md](02-microfrontends-architecture.md) — Explanation of microfrontends and the container/remote/footer structure used here.
+- [03-webpack-setup.md](03-webpack-setup.md) — Webpack setup, loaders, plugins, devServer ports and important options used across packages.
+- [04-module-federation.md](04-module-federation.md) — Module Federation concepts and exact exposes/remotes/shared configuration present in the repo.
+- [05-unit-testing-jest.md](05-unit-testing-jest.md) — Jest setup, Testing Library usage, mocking strategies (including federated remotes) and commands.
+- [06-code-coverage.md](06-code-coverage.md) — How Jest coverage is generated per-package, merged, and passed to SonarCloud/CI.
+- [07-github-actions-ci.md](07-github-actions-ci.md) — GitHub Actions (Sonar workflow) explanation, artifact handling, required secrets and troubleshooting.
+- [08-important-configs.md](08-important-configs.md) — Quick reference: TypeScript, Babel, Jest, css-loader flags and package-level scripts.
+- [09-css-to-cssmodule.md](09-css-to-cssmodule.md) — Step-by-step migration guide from global `.css` to `.module.css`, TypeScript and Jest notes.
+
+How to use:
+
+- Open the file for the topic you need while recording or troubleshooting. For quick demos, start with `02-microfrontends-architecture.md` and `04-module-federation.md`.

--- a/documentations/01-monorepo-lerna.md
+++ b/documentations/01-monorepo-lerna.md
@@ -1,0 +1,67 @@
+# Monorepo & Lerna — what it is and how this repo is set up
+
+What is a monorepo?
+
+- A monorepo stores many related packages (libraries/apps) inside a single repository. It simplifies sharing code, running cross-package scripts, and orchestrating builds/tests across packages.
+
+Why use Lerna + Yarn workspaces here?
+
+- Lerna provides orchestration for running scripts across packages (e.g., start, build, test). This repo uses Lerna with Yarn/NPM workspaces so dependencies can be hoisted to the root and scripts can be executed per-package or in parallel.
+
+How this repo is configured (exact files to inspect)
+
+- `lerna.json` (root) — uses independent versioning and declared packages:
+  - key snippet: "packages": [ "packages/*" ]
+  - version: "independent"
+
+- `package.json` (root) — workspace and scripts:
+  - `workspaces`: ["packages/*"] ensures package manager treats `packages/*` as workspace packages.
+  - Useful scripts in root:
+    - `test`: `lerna run test --stream` — runs `test` script in each package and streams output.
+    - `test:coverage`: `npx lerna run test --stream -- --coverage` — runs tests with coverage flag.
+    - `start`: `npx lerna run start --parallel` — starts all packages' dev servers in parallel.
+    - `build`: `npx lerna run build`
+
+How to run common tasks locally
+
+- Install dependencies at repo root (recommended):
+
+```powershell
+# PowerShell / pwsh
+cd "<repo-root>"
+yarn install
+```
+
+- Start all dev servers (container, remote, footer):
+
+```powershell
+yarn start
+```
+
+- Run tests across all packages:
+
+```powershell
+yarn test
+```
+
+- Run tests with coverage (root script):
+
+```powershell
+yarn test:coverage
+```
+
+Notes and troubleshooting
+
+- If a package can't find a dependency, ensure the dep is present in either the package's package.json (package-scoped) or hoisted at the root `package.json`.
+- Lerna commands in `package.json` use `npx lerna` to ensure the local lerna binary is used if installed in devDependencies.
+- When modifying package.json in a package, re-run `yarn install` to refresh workspace links.
+
+Files to review for a deep dive
+
+- `lerna.json`
+- root `package.json`
+- `packages/container/package.json`, `packages/remote/package.json`, `packages/footer/package.json`
+
+Why this matters for your recordings
+
+- Understanding the monorepo tooling helps you explain how flipping between packages (container, remote, footer) works without separate repos. The Lerna scripts are the single command entrypoints you’ll probably show in demos (start, build, test).

--- a/documentations/02-microfrontends-architecture.md
+++ b/documentations/02-microfrontends-architecture.md
@@ -1,0 +1,45 @@
+# Microfrontends (MFE) — what it is and how this repo implements it
+
+What are microfrontends?
+
+- Microfrontends split a large frontend into smaller, independently deployable frontend apps (each with its own build and deploy lifecycle). They let independent teams ship features without coordinating a monolithic frontend release.
+
+This repo's MFE layout
+
+- There are three packages under `packages/`:
+  - `container` — the host application that composes and loads remote microfrontends.
+  - `remote` — a micro-app exposing components (e.g., `Header`) that the container consumes.
+  - `footer` — another micro-app exposing footer functionality.
+
+How they communicate / integrate
+
+- The apps are integrated at runtime by Webpack Module Federation (see the Module Federation doc). The container lists the remotes (URLs) it expects; remote apps expose modules by name.
+- In development, each package runs its own dev server (ports 3000, 3001, 3002 in this repo). In production builds the remotes are uploaded and served (this repo shows S3-hosted remote entries in `packages/container/webpack.config.js`).
+
+Files to inspect for MFE wiring
+
+- `packages/container/webpack.config.js` — declares remotes (currently pointing to S3 URLs; local alternatives are commented out). Example snippet:
+  - `remotes: { remote: "remote@https://.../remoteEntry.js", footer: "footer@https://.../remoteEntry.js" }`
+
+- `packages/remote/webpack.config.js` — exposes modules:
+  - `exposes: { "./Header": "./src/components/Header" }`
+
+- `packages/footer/webpack.config.js` — exposes modules (example: `"./Footer": "./src/bootstrap"`).
+
+Running locally vs production
+
+- Local development: use the dev server URLs; in `container` webpack config there are commented lines showing:
+  - `remote: "remote@http://localhost:3001/remoteEntry.js"`
+  - `footer: "footer@http://localhost:3002/remoteEntry.js"`
+- Production: the container expects the remoteEntry to be hosted (in this repo an S3 URL is configured). Make sure CORS and correct public paths are set on the hosting.
+
+Common MFE gotchas to mention on camera
+
+- Duplicate React instances: always mark `react` and `react-dom` as shared singletons to avoid runtime errors.
+- Version mismatches in shared dependencies: ensure compatible versions or pin versions when necessary.
+- Remote loading failures: check network URL, CORS, and that `remoteEntry.js` is accessible.
+- Public path: Module Federation often needs `output.publicPath = 'auto'` for correct chunk loading.
+
+Why this structure is useful for teaching
+
+- You can demonstrate a complete MFE workflow: start each app in separate terminals, make a change in `remote` and show the container consuming it without rebuild. Also show how to host remoteEntry on S3/host and point the container to the production URL.

--- a/documentations/03-webpack-setup.md
+++ b/documentations/03-webpack-setup.md
@@ -1,0 +1,59 @@
+# Webpack — what it is and how this repo uses it
+
+What is Webpack?
+
+- Webpack is a bundler that processes application source files (JS/TS/CSS/assets) and produces optimized bundles for development or production. It supports loaders (to transform files) and plugins (to extend behavior).
+
+This repo's webpack basics
+
+- Each package (`container`, `remote`, `footer`) ships a `webpack.config.js` tuned for TypeScript + Module Federation:
+  - `entry`: `./src/index.ts` (or `./src/index.tsx` in some packages)
+  - `mode`: `'development'` or uses `argv.mode` to decide
+  - `devServer`: different port per package (container: 3000, remote: 3001, footer: 3002)
+  - `output.publicPath`: `auto` (required for Module Federation)
+
+Key loaders and rules present
+
+- TypeScript/JS: `ts-loader` handles `.ts/.tsx/.js/.jsx` files and excludes `node_modules` and test files.
+- CSS Modules: a rule for `\.module\.css$` using `style-loader` + `css-loader` with options `{ esModule: false, modules: true }`. The `esModule: false` is important to keep the CSS import shape compatible with `import styles from './x.module.css'`.
+- Global CSS: rule for `\.css$` that excludes `.module.css` and uses `style-loader` + `css-loader`.
+
+Plugins
+
+- `HtmlWebpackPlugin` — generates `index.html` for dev and injects bundles.
+- `ModuleFederationPlugin` — used in each package to either `expose` or `consume` federated modules (see Module Federation doc).
+- `EnvironmentPlugin` and `DefinePlugin` (in `container`) are used to inject build-time environment values.
+
+Ports used by dev servers
+
+- `container` — 3000
+- `remote` — 3001
+- `footer` — 3002
+
+Commands (package-level)
+
+From a package folder, common scripts are defined in `packages/*/package.json`:
+
+```powershell
+# run a single package dev server
+cd packages/remote
+yarn start
+
+# build production bundle for that package
+yarn build
+
+# run tests for that package
+yarn test
+```
+
+Tips and things to show on-camera
+
+- Demonstrate changing a CSS module and show HMR in a running remote and how the container picks it up if using local remotes.
+- Show how `esModule: false` avoids `styles.default` being required to access class names.
+- Explain why `publicPath: 'auto'` is required for Module Federation to locate remote chunks.
+
+Where to look in the repo
+
+- `packages/container/webpack.config.js`
+- `packages/remote/webpack.config.js`
+- `packages/footer/webpack.config.js`

--- a/documentations/04-module-federation.md
+++ b/documentations/04-module-federation.md
@@ -1,0 +1,74 @@
+# Webpack Module Federation — concept and how it’s set up in this repo
+
+What is Module Federation?
+
+- Module Federation (Webpack 5) lets JavaScript applications share code and dynamically load modules from other independently-built apps at runtime. It makes microfrontends practical by allowing remotes to expose modules and hosts (containers) to consume them.
+
+Key concepts
+
+- host/container: the app that consumes remote modules.
+- remote(s): apps that expose modules (components or utilities).
+- remoteEntry.js: the manifest file published by a remote that container uses to load remote modules at runtime.
+- exposes/remotes/shared: the mapping of what a remote exposes and what a container expects.
+
+How this repo configures Module Federation
+
+- `packages/remote/webpack.config.js`:
+  - `name: 'remote'`
+  - `filename: 'remoteEntry.js'`
+  - `exposes: { './Header': './src/components/Header' }`
+  - `shared`: spreads `deps` and marks `react` & `react-dom` as singletons
+
+- `packages/footer/webpack.config.js`:
+  - `name: 'footer'`
+  - `filename: 'remoteEntry.js'`
+  - `exposes: { './Footer': './src/bootstrap' }`
+
+- `packages/container/webpack.config.js`:
+  - `name: 'container'`
+  - `remotes`: configured to load remoteEntry from S3 URLs for production:
+    - `remote: "remote@https://my-mfe-header-rahul.s3.ap-south-1.amazonaws.com/remoteEntry.js"`
+    - `footer: "footer@https://my-mfe-footer-rahul.s3.ap-south-1.amazonaws.com/remoteEntry.js"`
+  - Local dev URLs are commented as examples:
+    - `remote@http://localhost:3001/remoteEntry.js`
+    - `footer@http://localhost:3002/remoteEntry.js`
+
+Important options and why they matter
+
+- `publicPath: 'auto'` (set in remotes/footers outputs) — lets Webpack calculate correct runtime base path to load chunks remotely.
+- `shared.react` / `shared['react-dom']` with `{ singleton: true, requiredVersion: deps.react }` — avoids loading multiple React copies.
+- `filename: 'remoteEntry.js'` — this file must be accessible at the configured URL for the host to load the remote.
+
+How to test locally (recommended steps for demos)
+
+1. Start remote and footer in separate terminals:
+
+```powershell
+# Terminal A
+cd packages/remote
+yarn start
+
+# Terminal B
+cd packages/footer
+yarn start
+
+# Terminal C
+cd packages/container
+yarn start
+```
+
+2. Ensure `packages/container/webpack.config.js` uses local `http://localhost:3001/remoteEntry.js` and `http://localhost:3002/remoteEntry.js` lines (the repo has these lines commented — uncomment them for local demos).
+
+Troubleshooting common runtime issues
+
+- CORS / 404 when loading remoteEntry: check the remote's dev server URL or hosting path.
+- Duplicate React errors: ensure singletons in `shared` and compatible versions across packages.
+- Remote not found in production: confirm remoteEntry was uploaded and the container's remote URL points to the published remoteEntry.js.
+
+Files to show on camera
+
+- `packages/remote/webpack.config.js` (exposes)
+- `packages/footer/webpack.config.js` (exposes)
+- `packages/container/webpack.config.js` (remotes)
+
+This topic is great for your audience because it covers both the theory (how federation works) and the practical steps (how to wire up containers and remotes and debug common errors).

--- a/documentations/05-unit-testing-jest.md
+++ b/documentations/05-unit-testing-jest.md
@@ -1,0 +1,55 @@
+# Unit testing (Jest) — approach and setup in this repo
+
+What is unit testing?
+
+- Unit testing means testing small, isolated units of code (functions or components) to ensure they behave as expected. For React apps we commonly test components using Jest + Testing Library.
+
+This repo's testing stack
+
+- Jest as the test runner.
+- Babel for transforming JSX/TypeScript in tests (`babel-jest` + `babel.config.js`).
+- `@testing-library/react` and `@testing-library/jest-dom` for rendering components and DOM assertions.
+- `identity-obj-proxy` for mocking CSS imports.
+
+Where tests and configs live
+
+- Each package has `jest.config.js` (examples: `packages/container/jest.config.js`, `packages/remote/jest.config.js`). Important options:
+  - `transform: { '^.+\\.[jt]sx?$': 'babel-jest' }`
+  - `moduleNameMapper` maps CSS to `identity-obj-proxy` and static assets to file mocks.
+  - `setupFilesAfterEnv: ['@testing-library/jest-dom']`
+  - `collectCoverage: true` and coverage reporters configured.
+
+Running tests
+
+- From the repo root (runs tests across packages using Lerna):
+
+```powershell
+yarn test
+```
+
+- From a package directory:
+
+```powershell
+cd packages/remote
+yarn test
+```
+
+Mocking Module Federation remotes in tests
+
+- Module Federation remotes are not available during Jest tests by default. Options to handle this:
+  - create manual mocks under `packages/container/__mocks__/remote/Header.js` (or `packages/remote/src/__mocks__/...`) — this repo already contains example mocks in `__mocks__` folders.
+  - use `jest.mock('remote/Header', () => ({ __esModule: true, default: () => <div>Mock</div> }));` in test files.
+
+Static assets and CSS in tests
+
+- Use `moduleNameMapper` and `identity-obj-proxy` so `import './App.css'` doesn't throw during tests.
+- File mocks (e.g., `__mocks__/fileMock.js`) should export a string like `module.exports = 'test-file-stub'`.
+
+Troubleshooting tips
+
+- If you see "Support for the experimental syntax 'jsx' isn't currently enabled": ensure `babel.config.js` exists at repo root and includes `@babel/preset-react`.
+- If Jest finds multiple configs, remove duplicate `jest.config.*` files in the package.
+
+Why this is helpful for your videos
+
+- You can show how to run package tests, add component tests, and how to mock federated imports — which is a crucial part of testing MFEs.

--- a/documentations/06-code-coverage.md
+++ b/documentations/06-code-coverage.md
@@ -1,0 +1,43 @@
+# Code coverage — what it is and how this repo collects and uses it
+
+What is code coverage?
+
+- Code coverage measures how much of your code is executed by tests. `lcov` is a common format for coverage reports and tools like SonarCloud can ingest lcov to show coverage metrics.
+
+How coverage is configured in this repo
+
+- Each package's `jest.config.js` sets:
+  - `collectCoverage: true`
+  - `collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/index.{js,ts,tsx}', '!src/**/types.{ts,tsx}']`
+  - `coverageDirectory: 'coverage'`
+  - `coverageReporters: ['text', 'lcov', 'html']`
+
+- Root `package.json` scripts include `test:coverage` that runs Lerna tests with `--coverage` (`npx lerna run test --stream -- --coverage`).
+- There’s a `merge-coverage` script (`node scripts/merge-lcov.js`) — this repository uses a merge step to combine per-package lcov reports into a single report for consumption by Sonar or other tools.
+
+SonarCloud / CI integration (as configured in `.github/workflows/sonar_scan.yml`)
+
+- The workflow downloads coverage artifacts named `container-coverage`, `remote-coverage`, and `footer-coverage` to `packages/*/coverage` paths.
+- It passes `-Dsonar.javascript.lcov.reportPaths=packages/container/coverage/lcov.info,packages/remote/coverage/lcov.info,packages/footer/coverage/lcov.info` to SonarCloud so the lcov files are read.
+
+How to run coverage locally
+
+1. Run per-package coverage via Lerna from repo root:
+
+```powershell
+# runs jest --coverage in each package
+yarn test:coverage
+```
+
+2. Inspect each package's `coverage/lcov.info` and `coverage/index.html`.
+
+3. If you want a single combined report, use or adapt `scripts/merge-lcov.js` (the repo has a `merge-coverage` script) and then open the generated `lcov-report/index.html`.
+
+Troubleshooting coverage problems
+
+- Missing `lcov.info` files in CI: ensure package test jobs upload coverage as artifacts, and that the sonar workflow downloads them to `packages/*/coverage` before running SonarCloud scan.
+- File paths in `lcov.info` may be relative; the Sonar workflow sets `rootDir` in package Jest configs to help Sonar map paths correctly.
+
+Demo ideas for your channel
+
+- Show running tests with coverage, opening the `coverage/index.html`, and then uploading/inspecting the same in SonarCloud or showing the merged HTML report.

--- a/documentations/07-github-actions-ci.md
+++ b/documentations/07-github-actions-ci.md
@@ -1,0 +1,39 @@
+# GitHub Actions — what they are and how this repo uses them (Sonar scan example)
+
+What are GitHub Actions?
+
+- GitHub Actions are automated workflows that run on GitHub events or can be invoked manually. They’re commonly used for CI: testing, linting, building, and running scans like SonarCloud.
+
+How this repo uses Actions (file to inspect)
+
+- `.github/workflows/sonar_scan.yml` — a callable workflow that performs a SonarCloud scan using coverage artifacts.
+
+Key parts of `sonar_scan.yml` (highlights)
+
+- The workflow is `workflow_call` type and expects a `SONAR_TOKEN` secret and `github_token` input.
+- It runs on `ubuntu-latest` and uses Node 20 (`actions/setup-node@v4`).
+- Download coverage artifacts step: uses `actions/download-artifact@v4` to fetch `container-coverage`, `remote-coverage`, `footer-coverage` into `packages/*/coverage` paths (these steps use `continue-on-error: true` so the workflow continues even when an artifact is missing).
+- SonarCloud scan step: `sonarsource/sonarcloud-github-action@v2` with args including `sonar.organization`, `sonar.projectKey`, `sonar.sources`, `sonar.tests`, `sonar.exclusions`, and `sonar.javascript.lcov.reportPaths` listing the packages' lcov files.
+- It finishes by running the SonarCloud quality gate check (`sonarsource/sonarqube-quality-gate-action@master`).
+
+How to trigger and use this workflow
+
+- This workflow is callable from other workflows (because it uses `workflow_call`). You can either:
+  - call it from a separate CI workflow once coverage artifacts are uploaded, or
+  - run it manually via the GitHub UI if you create a calling workflow.
+
+Required secrets and permissions
+
+- `SONAR_TOKEN` (stored in repository or organization secrets) — used by SonarCloud action.
+- `github_token` input — used in the SonarCloud step to update PR decorations/status.
+
+Troubleshooting CI issues
+
+- Sonar can't find lcov files: ensure coverage artifacts are uploaded by the jobs that run tests and that artifact names match what `sonar_scan.yml` downloads.
+- SonarCloud authentication errors: check `SONAR_TOKEN` and that account has access to the Sonar organization/project.
+- If `find` or `ls` in the debug step shows no `.info` files, fix earlier test jobs to generate and upload coverage.
+
+What to show on camera
+
+- Walk through `sonar_scan.yml` lines that specify `sonar.javascript.lcov.reportPaths` and show where Jest writes `coverage/lcov.info` in each package.
+- Show a CI run that uploads coverage artifacts, then demonstrate this workflow consuming them and running SonarCloud.

--- a/documentations/08-important-configs.md
+++ b/documentations/08-important-configs.md
@@ -1,0 +1,59 @@
+# Important configurations — TypeScript, Babel, Jest, and package-level details
+
+This file collects the small but important configurations you’ll want to reference quickly while recording.
+
+TypeScript (`tsconfig.json`)
+
+- Key `compilerOptions` used in packages (example from `packages/container/tsconfig.json`):
+  - `target: 'es5'`, `module: 'esnext'`, `moduleResolution: 'node'`
+  - `jsx: 'react-jsx'` — uses the new JSX transform
+  - `strict: true`, `esModuleInterop: true`, `allowSyntheticDefaultImports: true`
+  - `noEmit: false` (adjustable if you want to prevent TS compilation during tests)
+
+Babel (`babel.config.js` in repo root)
+
+- The root `babel.config.js` contains presets:
+  - `@babel/preset-env` (target: current node for test environments)
+  - `@babel/preset-react` with `{ runtime: 'automatic' }` (new JSX runtime)
+  - `@babel/preset-typescript`
+
+Jest configs (package-level)
+
+- Each package's `jest.config.js` includes:
+  - `transform` → `babel-jest`
+  - `moduleNameMapper` → CSS mapped to `identity-obj-proxy`, assets mapped to file mocks
+  - `collectCoverage` and `coverageReporters` configured
+  - `setupFilesAfterEnv: ['@testing-library/jest-dom']`
+
+CSS Loader / CSS Modules note
+
+- `css-loader` is configured with `esModule: false, modules: true` for `.module.css`. This ensures imports like `import styles from './a.module.css'` yield `styles.className` directly instead of `styles.default.className`.
+
+Package-level scripts
+
+- Packages expose `start`, `build`, `serve`, `clean`, and `test` scripts in `packages/*/package.json`. Root scripts use Lerna to orchestrate these across packages.
+
+Where to look in the repo
+
+- `babel.config.js` (root)
+- `packages/*/tsconfig.json`
+- `packages/*/jest.config.js`
+- `packages/*/webpack.config.js`
+- `packages/*/package.json` (to show scripts and dependencies)
+
+Quick commands to verify environment
+
+```powershell
+# install workspace deps
+yarn install
+
+# run container dev server
+cd packages/container
+yarn start
+
+# run remote tests
+cd packages/remote
+yarn test
+```
+
+This file is a quick go-to when you forget small flags or exact options used around Babel, TypeScript and Jest.

--- a/documentations/09-css-to-cssmodule.md
+++ b/documentations/09-css-to-cssmodule.md
@@ -1,0 +1,50 @@
+# Switching from global .css to .module.css (CSS Modules) — configuration and migration steps
+
+Why move to CSS Modules?
+
+- CSS Modules scope class names locally to a component, avoiding global class name collisions and making styles easier to reason about in large apps or microfrontends.
+
+Webpack configuration in this repo (how CSS Modules are wired)
+
+- Webpack has two rules:
+  - `test: \.module\.css$` — uses `style-loader` + `css-loader` with `{ esModule: false, modules: true }`
+  - `test: \.css$` (exclude `.module.css`) — uses `style-loader` + `css-loader` (global css)
+
+Why `esModule: false`?
+
+- css-loader v3+ defaults to ES modules. When `esModule: true`, you often have to use `styles.default.button` to access classes. Setting `esModule: false` preserves the CommonJS-style export (`styles.button`) which matches how imports are used across this repo.
+
+Steps to migrate a component to CSS Modules
+
+1. Rename the CSS file
+  - From `Button.css` to `Button.module.css`.
+
+2. Update import in component
+  - From `import './Button.css'` (global) to `import styles from './Button.module.css'`.
+  - Replace usage: `className="btn primary"` → `className={styles.primary}` (or `className={`${styles.btn} ${styles.primary}`}` when combining).
+
+3. TypeScript: add or update type declarations
+  - If TypeScript complains, add a `global.d.ts` (or `src/global.d.ts`) with:
+
+```ts
+declare module '*.module.css';
+```
+
+- This repo already contains `@types/css-modules` in dependencies — you can also use `css-modules-typescript-loader` or `typescript-plugin-css-modules` to generate typed class names for autocompletion.
+
+4. Update tests
+  - Jest maps `*.module.css` to `identity-obj-proxy` in `moduleNameMapper`, so tests continue to work. Ensure your package `jest.config.js` includes `'\\.(css|less|scss|sass|module\\.css)$': 'identity-obj-proxy'`.
+
+5. Be careful with dynamic class names
+  - CSS Modules generate unique hashed class names. If your code looked up classes by hard-coded string names or relied on global selectors, you’ll need to adapt to the module approach.
+
+Common migration pitfalls
+
+- Forgetting to update import names — switching to default import `styles` is required to access `.class` keys.
+- Third-party libraries or global CSS that rely on global class names may break — keep shared global styles in `index.css` or a shared global stylesheet.
+- Server-side rendering: ensure you don’t serialize hashed names in a way that mismatches client-side builds.
+
+What to show on camera
+
+- Rename a single component’s stylesheet to `.module.css`, update the import, run the dev server and show styles still apply but are now scoped (inspect elements to show hashed class names).
+- Show how Jest still passes tests thanks to `identity-obj-proxy` mapping for `.module.css`.


### PR DESCRIPTION
This pull request significantly improves the developer and teaching experience for the micro-frontend module federation monorepo by rewriting the `README.md` and introducing a structured set of documentation files. The changes focus on making the setup, configuration, and troubleshooting process much clearer, while providing topic-specific deep-dive guides for teaching or onboarding purposes.

**Documentation overhaul and teaching resources:**

- Major rewrite of `README.md` to serve as a comprehensive teaching and setup guide, including clearer quickstart steps, common troubleshooting, and links to new documentation files for deep dives.
- Addition of a documentation index (`documentations/00-index.md`) that links to new, topic-specific markdown guides for monorepo setup, microfrontend architecture, Webpack, Module Federation, testing, coverage, CI, configuration flags, and CSS modules migration.

**New topic-specific documentation files:**

- Monorepo & Lerna: Added `documentations/01-monorepo-lerna.md` explaining monorepo structure, Lerna/Yarn workspace setup, and common scripts.
- Microfrontends architecture: Added `documentations/02-microfrontends-architecture.md` describing the container/remote/footer structure and runtime integration.
- Webpack configuration: Added `documentations/03-webpack-setup.md` detailing loaders, plugins, dev server ports, and configuration rationale.
- Module Federation: Added `documentations/04-module-federation.md` with a deep dive into exposes/remotes/shared setup, troubleshooting, and demo instructions.

These changes make the repository much more accessible for both new contributors and those using it as a teaching resource, providing clear, modular documentation and a greatly improved onboarding experience.